### PR TITLE
Add `pry-byebug` to development dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,11 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in redis_cluster.gemspec
 gemspec
+
+group :development do
+  platforms :mri do
+    if RUBY_VERSION >= "2.0.0"
+      gem "pry-byebug"
+    end
+  end
+end


### PR DESCRIPTION
This one's a pretty minor quality of life improvement, but having Byebug
around makes dropping into a debugger during development quite a bit
easier.