### PR TITLE
Add more detailed error messages and improve naming

### DIFF
--- a/lib/redis_cluster/errors.rb
+++ b/lib/redis_cluster/errors.rb
@@ -1,7 +1,26 @@
 module RedisCluster
-  NotSupportError = Class.new StandardError
+  class CommandNotSupportedError < StandardError
+    def initialize(command)
+      super("Command #{command} is not supported for Redis Cluster")
+    end
+  end
 
-  KeysNotAtSameSlotError = Class.new StandardError
+  class KeysNotAtSameSlotError < StandardError
+    def initialize(keys)
+      super("Keys must map to the same Redis Cluster slot when using " \
+        "EVAL/EVALSHA. Consider using Redis Cluster 'hash tags' (see " \
+        "documentation). Keys: #{keys}")
+    end
+  end
 
-  KeyNotAppointError = Class.new StandardError
+  class KeysNotSpecifiedError < StandardError
+    def initialize(command)
+      super("Keys must be specified for command #{command}")
+    end
+  end
+
+  # These error classes were renamed. These aliases are here for backwards
+  # compatibility.
+  KeyNotAppointError = KeysNotSpecifiedError
+  NotSupportError = CommandNotSupportedError
 end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+# These tests are extremely trivial (purposely so because it gives us a little
+# more flexibility around changing error messages), but are here to demonstrate
+# that these exceptions can be initialized without error and also shows their
+# basic usage.
+describe "errors" do
+  describe RedisCluster::CommandNotSupportedError do
+    it "initializes" do
+      RedisCluster::CommandNotSupportedError.new("GET")
+    end
+  end
+
+  describe RedisCluster::KeysNotAtSameSlotError do
+    it "initializes" do
+      RedisCluster::KeysNotAtSameSlotError.new(["foo", "bar"])
+    end
+  end
+
+  describe RedisCluster::KeysNotSpecifiedError do
+    it "initializes" do
+      RedisCluster::KeysNotSpecifiedError.new("GET")
+    end
+  end
+end


### PR DESCRIPTION
While developing a project with `redis_cluster` initially, I found
debugging some parts to be quite difficult because the errors thrown by
the library don't have messages and as a result, are quite vague. This
patch adds some explanatory messages to each error class which will
hopefully be helpful to users who are trying to debug.

A little more contentious is that I renamed a couple of the classes so
that they're more grammatically correct. I've added backwards-compatible
type aliases for them so that this isn't a breaking change, but those
could plausibly be dropped on the next major version increment.