### PR TITLE
Refactor and document `#execute` + configuration + remove sleep

### DIFF
--- a/lib/redis_cluster/configuration.rb
+++ b/lib/redis_cluster/configuration.rb
@@ -2,7 +2,6 @@ module RedisCluster
 
   class Configuration
     HASH_SLOTS = 16384
-    REQUEST_TTL = 16
     DEFAULT_TIMEOUT = 1
 
     SUPPORT_SINGLE_NODE_METHODS = %w(


### PR DESCRIPTION
Refactors the main `#execute` method so that "TTL" is replaced by a
retry counter. I don't think that this significantly changes the
previous behavior because "TTL" wasn't actually being used as a duration
anywhere -- instead, it was being mutated with some basic arithmetic and
checked to see if the loop should continue. A counter should do the same
job, but more simply.

Secondly, I've also tried to document the loop in a few places with what
I believe is the rational behind the existing behavior in a few of the
conditionals. This might be obvious to an experienced user of Redis
Cluster, but wasn't obvious to me when I first started looking at it.

Thirdly, I've added some configuration for `retry_count`. I think that
in some cases having this set to zero is probably the most sensible
configuration for some users who want more deterministic operation out
of the library (we would probably set it to zero). The trouble is that
retries within the library can be fairly opaque operations that produces
timing on runs that might be hard to predict -- in our use for example,
if a Redis is not reachable we usually want to just fail fast and move
on.

Probably most contentiously, I've removed the sleep statements from the
loop. I *think* the reason that they were written like this is that
after the loop has failed once and then maybe got a move, we want to
start doing some sort of back off because further failure probably means
that the cluster is in a bad state. This seems reasonable, but if that's
the case I think it would be better to solidify and document the
rational because it's not super obvious. Let me know if they are
important, and if so, I'll bring them back and update this patch.