### PR TITLE
Use hash instead of optional parameters for Ruby 1.9 compatibility

### DIFF
--- a/lib/redis_cluster/client.rb
+++ b/lib/redis_cluster/client.rb
@@ -91,7 +91,9 @@ module RedisCluster
     # is used, but if the `use_initial_hosts` is set to `true`, then the client
     # is completely refreshed and the hosts that were specified when creating
     # it originally are set instead.
-    def reconnect(use_initial_hosts: false)
+    def reconnect(options = {})
+      use_initial_hosts = options.fetch(:use_initial_hosts, false)
+
       @hosts = @initial_hosts.dup if use_initial_hosts
 
       @mutex.synchronize do


### PR DESCRIPTION
Switches to an `options` hash instead of optional parameters so that we
can maintain compatibility with Ruby 1.9.

This approach is nice because when 1.9 support is dropped it's _mostly_
forward compatible if we then want to switch to optional parameters. It
does have the fairly sizable disadvantage though in that unlike optional
parameters, option names are not checked, so it's easy to misspell a
name like `use_initial_hosts` and not notice.

Addresses some feedback here:
https://github.com/zhchsf/redis_cluster/pull/15#issuecomment-367371837