### PR TITLE
Add default to keys, fix scan and allow options overrides

### DIFF
--- a/lib/redis_cluster/client.rb
+++ b/lib/redis_cluster/client.rb
@@ -118,6 +118,11 @@ module RedisCluster
       execute(method, args, &block)
     end
 
+    # Add default argument to keys to match redis client interface
+    def keys(glob = "*", &block)
+      execute("keys", [glob], &block)
+    end
+
     # Closes all open connections and reloads the client pool.
     #
     # Normally host information from the last time the node pool was reloaded

--- a/lib/redis_cluster/configuration.rb
+++ b/lib/redis_cluster/configuration.rb
@@ -16,7 +16,7 @@ module RedisCluster
       hincrby hincrbyfloat hkeys hvals hgetall publish pfadd
     ).freeze
 
-    SUPPORT_MULTI_NODE_METHODS = %w(keys script multi pipelined).freeze
+    SUPPORT_MULTI_NODE_METHODS = %w(keys script multi pipelined scan).freeze
 
     def self.method_names
       SUPPORT_SINGLE_NODE_METHODS + SUPPORT_MULTI_NODE_METHODS

--- a/lib/redis_cluster/node.rb
+++ b/lib/redis_cluster/node.rb
@@ -41,8 +41,8 @@ module RedisCluster
     end
 
     def self.redis(options)
-      extra_options = {timeout: Configuration::DEFAULT_TIMEOUT, driver: 'hiredis'.freeze}
-      ::Redis.new(options.merge(extra_options))
+      default_options = {timeout: Configuration::DEFAULT_TIMEOUT, driver: 'hiredis'.freeze}
+      ::Redis.new(default_options.merge(options))
     end
 
   end # end Node

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,15 +1,16 @@
 require "spec_helper"
 
 describe "client" do
-  let(:pool_nodes) {@redis.instance_variable_get("@pool").nodes}
+  let(:pool)       {@redis.instance_variable_get("@pool")}
+  let(:pool_nodes) {pool.nodes}
   let(:pool_hosts) {pool_nodes.map{|n| n.host_hash[:host]}}
   let(:pool_ports) {pool_nodes.map{|n| n.host_hash[:port]}}
 
   before do
     cluster_nodes = [
-      [1000, 5460, ["127.0.0.1", 7003], ["127.0.0.1", 7000]], 
-      [0, 999, ["127.0.0.1", 7006], ["127.0.0.1", 7007]], 
-      [10923, 16383, ["127.0.0.1", 7002], ["127.0.0.1", 7005]], 
+      [1000, 5460, ["127.0.0.1", 7003], ["127.0.0.1", 7000]],
+      [0, 999, ["127.0.0.1", 7006], ["127.0.0.1", 7007]],
+      [10923, 16383, ["127.0.0.1", 7002], ["127.0.0.1", 7005]],
       [5461, 10922, ["127.0.0.1", 7004], ["127.0.0.1", 7001]]
     ]
     allow_any_instance_of(Redis).to receive(:cluster).and_return(cluster_nodes)
@@ -197,6 +198,14 @@ describe "client" do
       # instead of just the ones that we configured originally.
       expect(pool_hosts).to eq(["127.0.0.1"])
       expect(pool_ports).to eq(["7000"])
+    end
+  end
+
+  describe "keys" do
+    it "supports a default argument" do
+      allow(pool).to receive(:execute).with("keys", ["*"], {asking: false, random_node: false}).and_return(["abc", "def"])
+      result = @redis.keys
+      expect(result).to eq(["abc", "def"])
     end
   end
 end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -39,5 +39,14 @@ describe "node" do
     it "has a redis connection" do
       expect(subject.connection.class.name).to eq "Redis"
     end
+
+    it "should allow the default options to be overridden" do
+      other_node = RedisCluster::Node.new(host: '127.0.0.1', port: 6379, timeout: 20, driver: 'ruby')
+
+      connection_options = other_node.connection.instance_variable_get("@options")
+
+      expect(connection_options[:timeout]).to eq(20)
+      expect(connection_options[:driver]).to eq('ruby')
+    end
   end
 end

--- a/spec/pool_spec.rb
+++ b/spec/pool_spec.rb
@@ -93,6 +93,51 @@ describe "pool" do
       it_behaves_like "slots exclude", 1888
     end
 
+    describe "scan" do
+      # First iteration, finds one element from the first node and reports there is more to scan...
+      it "returns an expanded cursor for the same node when scan returns a nonzero value" do
+        allow(@pool.nodes.first).to receive(:execute).with("scan", ["0", {}]).and_return(["2", ["abc"]])
+
+        cursor, keys = @pool.execute(:scan, ["0", {}], {})
+
+        # There are two nodes in the pool, so the scan cursor is doubled...
+        expect(cursor).to eq "4"
+        expect(keys).to eq ["abc"]
+      end
+
+      # Second iteration, using the cursor from before, returns the last element from the first node...
+      it "returns a cursor that points to the next node when scan returns a zero value" do
+        allow(@pool.nodes.first).to receive(:execute).with("scan", ["2", {}]).and_return(["0", ["def"]])
+
+        cursor, keys = @pool.execute(:scan, ["4", {}], {})
+
+        # Hitting the zero element on the second pool.
+        expect(cursor).to eq "1"
+        expect(keys).to eq ["def"]
+      end
+
+      # Third iteration, using the previously returned cursor.  Returns an element from the second node and reports more to scan
+      it "selects the correct node based on the passed cursor" do
+        allow(@pool.nodes.last).to receive(:execute).with("scan", ["0", {}]).and_return(["1", ["ghi"]])
+
+        cursor, keys = @pool.execute(:scan, ["1", {}], {})
+
+        # Hitting the zero element on the second pool.
+        expect(cursor).to eq "3"
+        expect(keys).to eq ["ghi"]
+      end
+
+      # Third iteration, using the previously returned cursor.  Returns the last element from the second node
+      it "reports zero when the last element on the last node is scanned" do
+        allow(@pool.nodes.last).to receive(:execute).with("scan", ["1", {}]).and_return(["0", ["jkl"]])
+
+        cursor, keys = @pool.execute(:scan, ["3", {}], {})
+
+        # Hitting the zero element on the second pool.
+        expect(cursor).to eq "0"
+        expect(keys).to eq ["jkl"]
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Hi, thank you for this project.  It has been a great help.   We made three changes that I hope you would be willing to accept.  

* Added a default argument to the keys command so that it works the same as the Redis gem.   This is very helpful in our test environments where we jump between clustered and unclustered operations.
* Created a cluster aware scan that can scan all nodes in the cluster.   It does this by encoding the node that is being scanned into the scan cursor. (The existing scan would use the cursor to find the node to target, which caused some very surprising results.) 
* Allowed the timeout and driver options to be overridden.  The default options were overwriting the parameters passed in the constructor.  I just changed the merge order. 

I added tests for all of these.   Please let me know if there is anything else you would like to see.  

Thanks again
